### PR TITLE
テスト追加

### DIFF
--- a/iOSEngineerCodeCheckTests/iOSEngineerCodeCheckTests.swift
+++ b/iOSEngineerCodeCheckTests/iOSEngineerCodeCheckTests.swift
@@ -9,26 +9,91 @@
 import XCTest
 @testable import iOSEngineerCodeCheck
 
-class iOSEngineerCodeCheckTests: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+final class iOSEngineerCodeCheckTests: XCTestCase {
+    
+    func testGitHubAPIFetchSuccess() {
+        let expectation = XCTestExpectation(description: "Fetch GitHub repositories successfully")
+        let query = "swift"
+        let urlString = "\(GitHubAPI.searchURL)\(query)" 
+        guard let url = URL(string: urlString) else {
+            XCTFail("Invalid URL")
+            return
         }
-    }
 
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            if let error = error {
+                XCTFail("Error occurred: \(error.localizedDescription)")
+                return
+            }
+            
+            guard let data = data else {
+                XCTFail("No data received")
+                return
+            }
+            
+            do {
+                let json = try JSONSerialization.jsonObject(with: data, options: [])
+                guard let dictionary = json as? [String: Any],
+                      let items = dictionary["items"] as? [[String: Any]] else {
+                    XCTFail("Invalid JSON format")
+                    return
+                }
+                
+                XCTAssertGreaterThan(items.count, 0, "Repositories should not be empty")
+                expectation.fulfill()
+            } catch {
+                XCTFail("JSON parsing failed: \(error.localizedDescription)")
+            }
+        }
+        task.resume()
+        
+        wait(for: [expectation], timeout: 5.0)
+    }
+    
+    func testGitHubAPIFetchInvalidQuery() {
+        let expectation = XCTestExpectation(description: "Handle invalid search query gracefully")
+        let query = ""
+        let urlString = "\(GitHubAPI.searchURL)\(query)"
+        guard let url = URL(string: urlString) else {
+            XCTFail("Invalid URL")
+            return
+        }
+        
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            if let error = error {
+                XCTFail("Error occurred: \(error.localizedDescription)")
+                return
+            }
+            
+            guard let data = data else {
+                XCTFail("No data received")
+                return
+            }
+            
+            do {
+                let json = try JSONSerialization.jsonObject(with: data, options: [])
+                guard let dictionary = json as? [String: Any] else {
+                    XCTFail("Invalid JSON format")
+                    return
+                }
+                
+                if let message = dictionary["message"] as? String {
+                    // APIエラーが発生している場合
+                    XCTAssertTrue(message.contains("Validation Failed"), "Expected a validation error message")
+                } else if let items = dictionary["items"] as? [[String: Any]] {
+                    // 正常なレスポンスが返った場合
+                    XCTAssertEqual(items.count, 0, "Repositories should be empty for an invalid query")
+                } else {
+                    XCTFail("Unexpected response structure")
+                }
+                
+                expectation.fulfill()
+            } catch {
+                XCTFail("JSON parsing failed: \(error.localizedDescription)")
+            }
+        }
+        task.resume()
+
+        wait(for: [expectation], timeout: 10.0)
+    }
 }


### PR DESCRIPTION
> ## 関連issue
> [テストを追加](https://github.com/riku-tamura/ios-engineer-codecheck/issues/9)
> 
> ## 行ったこと
>1. 正常系テスト: 有効なクエリでリポジトリを取得
目的: GitHub APIが正常に動作し、有効な検索クエリに対して期待通りのレスポンスを返すか確認。
検索クエリ: "swift"
検証内容:
APIリクエストが成功すること。
レスポンスに含まれるitemsキー内に1件以上のリポジトリデータが存在すること。
>
>2. 異常系テスト: 無効なクエリでエラーハンドリングを確認
目的: GitHub APIに無効な検索クエリを送信した場合のエラーハンドリングを検証。
検索クエリ: 空文字列（""）
検証内容:
レスポンス内にエラーメッセージ（例: "Validation Failed"）が含まれていること。
もしくは、itemsキーが存在し、結果が空であること
>
>3. 実装方法
XCTestを使用して非同期テストを実施。
APIリクエストをURLSessionで送信し、レスポンスをJSONSerializationでパース。
正常系では、レスポンス内のリポジトリデータが正しく取得されていることをアサート。
異常系では、APIが適切なエラーメッセージまたは空のレスポンスを返していることをアサート。
>
>4. テスト結果
正常系: 有効なクエリで正しくリポジトリ一覧を取得できることを確認。
異常系: 無効なクエリに対してエラーメッセージや空の結果が返されることを確認。
